### PR TITLE
chore: ignore .a5c cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 claude-ai-rtl-transformer-v2.0.zip
 claude-ai-rtl-transformer-v2.1.0.zip
+.a5c/


### PR DESCRIPTION
Adds `.a5c/` to `.gitignore` — a local tool cache directory that was showing up as untracked noise in `git status`.

No code or extension behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)